### PR TITLE
[Feat] 카카오 로그인 및 JWT 토큰

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env
+application-secrets.yml

--- a/build.gradle
+++ b/build.gradle
@@ -36,12 +36,18 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	implementation 'mysql:mysql-connector-java:8.0.33'
 
+	//spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.1.RELEASE'
+
+	//JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	implementation 'mysql:mysql-connector-java:8.0.33'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.1.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	implementation 'mysql:mysql-connector-java:8.0.33'
-<<<<<<< HEAD
 
 	//spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -50,10 +49,6 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-=======
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.security:spring-security-crypto'
->>>>>>> e0ad439881904e64fc72af577e7577859549ebc4
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/stackpot/stackpot/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/stackpot/stackpot/apiPayload/code/status/ErrorStatus.java
@@ -13,7 +13,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "등록된 사용자가 없습니다."),;
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/stackpot/stackpot/config/security/CustomOAuth2UserService.java
+++ b/src/main/java/stackpot/stackpot/config/security/CustomOAuth2UserService.java
@@ -1,8 +1,6 @@
 package stackpot.stackpot.config.security;
 
-
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -14,52 +12,87 @@ import stackpot.stackpot.repository.UserRepository.UserRepository;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
 
-    @Override
-    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        OAuth2User oAuth2User = super.loadUser(userRequest);
+//    @Override
+//    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+//        OAuth2User oAuth2User = super.loadUser(userRequest);
+//
+//        // 사용자 정보 가져오기
+//        Map<String, Object> attributes = oAuth2User.getAttributes();
+//        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+//
+//        if (kakaoAccount == null) {
+//            throw new OAuth2AuthenticationException("Failed to retrieve kakao_account from attributes.");
+//        }
+//
+//        // 이메일 가져오기
+//        String email = (String) kakaoAccount.get("email");
+//        if (email == null) {
+//            throw new OAuth2AuthenticationException("Email not found in kakao_account.");
+//        }
+//        // 사용자 정보 조회 (DB에 저장 여부 확인)
+//        userRepository.findByEmail(email).ifPresentOrElse(
+//                user -> System.out.println("Existing user found: " + email),
+//                () -> System.out.println("No user found. Redirecting to signup.")
+//        );
+//
+//        Map<String, Object> modifiedAttributes = new HashMap<>(attributes);
+//        modifiedAttributes.put("email", email); // 확실히 email 필드가 포함되도록 보장
+//
+//        System.out.println("modifiedAttributes : " + modifiedAttributes);
+//
+//        if (!modifiedAttributes.containsKey("email")) {
+//            throw new IllegalStateException("Email is not present in modifiedAttributes!");
+//        }
+//        // 사용자 정보를 DefaultOAuth2User로 반환
+//        return new DefaultOAuth2User(
+//                oAuth2User.getAuthorities(),
+//                attributes,
+//                "email" // Principal로 사용할 필드
+//        );
+//    }
+@Override
+public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        Map<String, Object> attributes = oAuth2User.getAttributes();
-        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+    // 사용자 정보 가져오기
+    Map<String, Object> attributes = oAuth2User.getAttributes();
+    Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
 
-        String email = (String) properties.get("email");
-
-        // 사용자 정보 조회
-        User user = userRepository.findByEmail(email).orElse(null);
-
-        // 리다이렉션 상태 플래그 추가
-        Map<String, Object> modifiedAttributes = new HashMap<>(attributes);
-        modifiedAttributes.put("email", email);
-        if (user == null) {
-            // 회원가입 페이지로 리다이렉션
-            modifiedAttributes.put("redirect", String.format("/signup?email=%s", email));
-        } else {
-            // 홈 페이지로 리다이렉션
-            modifiedAttributes.put("redirect", "/home");
-        }
-
-        return new DefaultOAuth2User(
-                oAuth2User.getAuthorities(),
-                modifiedAttributes,
-                "email"  // Principal로 설정
-        );
+    if (kakaoAccount == null) {
+        throw new OAuth2AuthenticationException("Failed to retrieve kakao_account from attributes.");
     }
 
-    private User saveOrUpdateUser(String email) {
-        User user = userRepository.findByEmail(email)
-                .orElse(User.builder()
-                        .email(email)
-                        .kakaoId(passwordEncoder.encode("OAUTH_USER_" + UUID.randomUUID()))
-                        .build());
-
-        return userRepository.save(user);
+    // 이메일 가져오기
+    String email = (String) kakaoAccount.get("email");
+    if (email == null) {
+        throw new OAuth2AuthenticationException("Email not found in kakao_account.");
     }
+
+    // 사용자 정보 확인
+    userRepository.findByEmail(email).ifPresentOrElse(
+            user -> System.out.println("Existing user found: " + email),
+            () -> System.out.println("No user found. Redirecting to signup.")
+    );
+
+    // attributes에 email 추가
+    Map<String, Object> modifiedAttributes = new HashMap<>(attributes);
+    modifiedAttributes.put("email", email);
+
+    // 디버깅: modifiedAttributes 확인
+    System.out.println("Final Modified Attributes: " + modifiedAttributes);
+
+    // DefaultOAuth2User 생성
+    return new DefaultOAuth2User(
+            oAuth2User.getAuthorities(),
+            modifiedAttributes,
+            "email" // Principal로 사용할 필드 이름
+    );
+}
 }

--- a/src/main/java/stackpot/stackpot/config/security/CustomOAuth2UserService.java
+++ b/src/main/java/stackpot/stackpot/config/security/CustomOAuth2UserService.java
@@ -32,17 +32,24 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String email = (String) properties.get("email");
 
-        // 사용자 정보 저장 또는 업데이트
-        User member = saveOrUpdateUser(email);
+        // 사용자 정보 조회
+        User user = userRepository.findByEmail(email).orElse(null);
 
-        // 이메일을 Principal로 사용하기 위해 attributes 수정
+        // 리다이렉션 상태 플래그 추가
         Map<String, Object> modifiedAttributes = new HashMap<>(attributes);
         modifiedAttributes.put("email", email);
+        if (user == null) {
+            // 회원가입 페이지로 리다이렉션
+            modifiedAttributes.put("redirect", String.format("/signup?email=%s", email));
+        } else {
+            // 홈 페이지로 리다이렉션
+            modifiedAttributes.put("redirect", "/home");
+        }
 
         return new DefaultOAuth2User(
                 oAuth2User.getAuthorities(),
                 modifiedAttributes,
-                "email"  // email Principal로 설정
+                "email"  // Principal로 설정
         );
     }
 

--- a/src/main/java/stackpot/stackpot/config/security/CustomOAuth2UserService.java
+++ b/src/main/java/stackpot/stackpot/config/security/CustomOAuth2UserService.java
@@ -1,0 +1,58 @@
+package stackpot.stackpot.config.security;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import stackpot.stackpot.domain.User;
+import stackpot.stackpot.repository.UserRepository.UserRepository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+
+        String email = (String) properties.get("email");
+
+        // 사용자 정보 저장 또는 업데이트
+        User member = saveOrUpdateUser(email);
+
+        // 이메일을 Principal로 사용하기 위해 attributes 수정
+        Map<String, Object> modifiedAttributes = new HashMap<>(attributes);
+        modifiedAttributes.put("email", email);
+
+        return new DefaultOAuth2User(
+                oAuth2User.getAuthorities(),
+                modifiedAttributes,
+                "email"  // email Principal로 설정
+        );
+    }
+
+    private User saveOrUpdateUser(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElse(User.builder()
+                        .email(email)
+                        .kakaoId(passwordEncoder.encode("OAUTH_USER_" + UUID.randomUUID()))
+                        .build());
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/stackpot/stackpot/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/stackpot/stackpot/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,41 @@
+package stackpot.stackpot.config.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.security.core.Authentication;
+
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/stackpot/stackpot/config/security/JwtTokenProvider.java
+++ b/src/main/java/stackpot/stackpot/config/security/JwtTokenProvider.java
@@ -1,0 +1,48 @@
+package stackpot.stackpot.config.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    private final long validityInMilliseconds = 3600000; // 1시간
+
+    // JWT 생성 (이메일 포함)
+    public String createToken(String email) {
+        Claims claims = Jwts.claims().setSubject(email);
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(key)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public String getEmailFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}

--- a/src/main/java/stackpot/stackpot/config/security/JwtTokenProvider.java
+++ b/src/main/java/stackpot/stackpot/config/security/JwtTokenProvider.java
@@ -2,16 +2,23 @@ package stackpot.stackpot.config.security;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
-
+import org.springframework.security.core.Authentication;
 import java.security.Key;
 import java.util.Date;
 
+@RequiredArgsConstructor
 @Component
 public class JwtTokenProvider {
 
+    // key 하드코딩 되어 있음 수정필요.
     private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
     private final long validityInMilliseconds = 3600000; // 1시간
+    private final UserDetailsService  userDetailsService;
 
     // JWT 생성 (이메일 포함)
     public String createToken(String email) {
@@ -44,5 +51,11 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject();
+    }
+
+    public Authentication getAuthentication(String token) {
+        String email = getEmailFromToken(token);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email); // 이메일로 사용자 로드
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 }

--- a/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
+++ b/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @EnableWebSecurity
@@ -29,5 +31,9 @@ public class SecurityConfig {
                 );
 
         return http.build();
+    }
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
+++ b/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
@@ -1,3 +1,47 @@
+//package stackpot.stackpot.config.security;
+//
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+//import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+//import org.springframework.security.crypto.password.PasswordEncoder;
+//import org.springframework.security.web.SecurityFilterChain;
+//
+//@EnableWebSecurity
+//@Configuration
+//public class SecurityConfig {
+//
+//    @Bean
+//    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+//        http
+//                .authorizeHttpRequests((requests) -> requests
+//                        .requestMatchers("/", "/home", "/signup","/swagger-ui/**", "/v3/api-docs/**").permitAll()
+//                        .anyRequest().authenticated()
+//                )
+//                .formLogin((form) -> form
+//                        .loginPage("/login")
+//                        .defaultSuccessUrl("/home", true)
+//                        .permitAll()
+//                )
+//                .logout((logout) -> logout
+//                        .logoutUrl("/logout")
+//                        .logoutSuccessUrl("/login?logout")
+//                        .permitAll()
+//                )
+//                .oauth2Login(oauth2 -> oauth2
+//                        .loginPage("/login")
+//                        .permitAll()
+//                );
+//
+//        return http.build();
+//    }
+//    @Bean
+//    public PasswordEncoder passwordEncoder() {
+//        return new BCryptPasswordEncoder();
+//    }
+//}
+
 package stackpot.stackpot.config.security;
 
 import org.springframework.context.annotation.Bean;
@@ -6,34 +50,58 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import stackpot.stackpot.repository.UserRepository.UserRepository;
 
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtTokenProvider jwtTokenProvider, UserRepository userRepository) throws Exception {
         http
-                .authorizeHttpRequests((requests) -> requests
-                        .requestMatchers("/", "/home", "/signup", "/user/profile","/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/", "/home", "/signup","user/signup", "/login", "/oauth2/**").permitAll()
                         .anyRequest().authenticated()
                 )
-                .formLogin((form) -> form
+                .oauth2Login(oauth2 -> oauth2
                         .loginPage("/login")
-                        .defaultSuccessUrl("/home", true)
-                        .permitAll()
+                        .successHandler(successHandler(jwtTokenProvider, userRepository)) // SuccessHandler 등록
                 )
-                .logout((logout) -> logout
-                        .logoutUrl("/logout")
-                        .logoutSuccessUrl("/login?logout")
-                        .permitAll()
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/signup")) // CSRF 예외 처리
+                .formLogin(form -> form
+                        .loginPage("/login").permitAll()
                 );
 
         return http.build();
     }
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationSuccessHandler successHandler(JwtTokenProvider jwtTokenProvider, UserRepository userRepository) {
+
+
+
+        return (request, response, authentication) -> {
+            OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+            String email = (String) oAuth2User.getAttributes().get("email");
+
+            // JWT 토큰 생성
+            String token = jwtTokenProvider.createToken(email);
+
+            if (userRepository.findByEmail(email).isPresent()) {
+                // 이메일이 존재하면 홈으로 리다이렉트
+                response.sendRedirect("/home?token=" + token);
+            } else {
+                // 이메일이 없으면 회원가입 페이지로 리다이렉트
+                response.sendRedirect("/signup?token=" + token);
+            }
+        };
     }
 }

--- a/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
+++ b/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
@@ -1,2 +1,33 @@
-package stackpot.stackpot.config.security;public class SecurityConfig {
+package stackpot.stackpot.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests((requests) -> requests
+                        .requestMatchers("/", "/home", "/signup", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin((form) -> form
+                        .loginPage("/login")
+                        .defaultSuccessUrl("/home", true)
+                        .permitAll()
+                )
+                .logout((logout) -> logout
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/login?logout")
+                        .permitAll()
+                );
+
+        return http.build();
+    }
 }

--- a/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
+++ b/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
@@ -57,11 +57,14 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import stackpot.stackpot.repository.UserRepository.UserRepository;
 
 @EnableWebSecurity
+@Configuration
 public class SecurityConfig {
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtTokenProvider jwtTokenProvider, UserRepository userRepository) throws Exception {
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/home", "/signup", "/user/signup", "/login", "/oauth2/**").permitAll()
+                        .requestMatchers("/", "/home", "/signup", "/user/profile","/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
@@ -91,12 +94,14 @@ public class SecurityConfig {
             // JWT 토큰 생성
             String token = jwtTokenProvider.createToken(email);
 
+            response.setHeader("Authorization", "Bearer " + token);
+
             if (userRepository.findByEmail(email).isPresent()) {
                 // 이메일이 존재하면 홈으로 리다이렉트
-                response.sendRedirect("/home?token=" + token);
+                response.sendRedirect("/home");
             } else {
                 // 이메일이 없으면 회원가입 페이지로 리다이렉트
-                response.sendRedirect("/signup?token=" + token);
+                response.sendRedirect("/signup");
             }
         };
     }

--- a/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
+++ b/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
@@ -16,7 +16,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests((requests) -> requests
-                        .requestMatchers("/", "/home", "/signup", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/", "/home", "/signup", "/user/profile","/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin((form) -> form

--- a/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
+++ b/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
@@ -1,0 +1,2 @@
+package stackpot.stackpot.config.security;public class SecurityConfig {
+}

--- a/src/main/java/stackpot/stackpot/converter/UserConverter.java
+++ b/src/main/java/stackpot/stackpot/converter/UserConverter.java
@@ -7,11 +7,11 @@ public class UserConverter {
     public static User toUser(UserRequestDTO.JoinDto request) {
 
         return User.builder()
-                .nickname(request.getNickname())
+//                .nickname(request.getNickname())
                 .email(request.getEmail())   // 추가된 코드
-                .kakaoId(request.getKakaoId())
-                .interest(request.getInterest())
-                .role(request.getRole())
+//                .kakaoId(request.getKakaoId())
+//                .interest(request.getInterest())
+//                .role(request.getRole())
                 .userTemperature((int)35.5)
                 .build();
     }

--- a/src/main/java/stackpot/stackpot/converter/UserConverter.java
+++ b/src/main/java/stackpot/stackpot/converter/UserConverter.java
@@ -1,0 +1,19 @@
+package stackpot.stackpot.converter;
+
+import stackpot.stackpot.domain.User;
+import stackpot.stackpot.web.dto.UserRequestDTO;
+
+public class UserConverter {
+    public static User toUser(UserRequestDTO.JoinDto request) {
+
+        return User.builder()
+                .nickname(request.getNickname())
+                .email(request.getEmail())   // 추가된 코드
+                .kakaoId(request.getKakaoId())
+                .interest(request.getInterest())
+                .role(request.getRole())
+                .userTemperature((int)35.5)
+                .build();
+    }
+}
+

--- a/src/main/java/stackpot/stackpot/domain/User.java
+++ b/src/main/java/stackpot/stackpot/domain/User.java
@@ -3,6 +3,7 @@ package stackpot.stackpot.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import stackpot.stackpot.domain.common.BaseEntity;
+import stackpot.stackpot.domain.enums.Role;
 
 @Entity
 @Getter

--- a/src/main/java/stackpot/stackpot/domain/User.java
+++ b/src/main/java/stackpot/stackpot/domain/User.java
@@ -2,15 +2,19 @@ package stackpot.stackpot.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 import stackpot.stackpot.domain.common.BaseEntity;
 import stackpot.stackpot.domain.enums.Role;
+
+import java.util.Collection;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class User extends BaseEntity {
+public class User extends BaseEntity implements UserDetails{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,4 +49,19 @@ public class User extends BaseEntity {
 
     @Column(nullable = false, unique = true)
     private String email; // 이메일
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return email; // 사용자 식별자로 이메일을 사용
+    }
 }

--- a/src/main/java/stackpot/stackpot/domain/enums/Role.java
+++ b/src/main/java/stackpot/stackpot/domain/enums/Role.java
@@ -1,0 +1,5 @@
+package stackpot.stackpot.domain.enums;
+
+public enum Role {
+    Design, Beckend, Frontend, PM;
+}

--- a/src/main/java/stackpot/stackpot/repository/UserRepository/UserRepository.java
+++ b/src/main/java/stackpot/stackpot/repository/UserRepository/UserRepository.java
@@ -1,0 +1,10 @@
+package stackpot.stackpot.repository.UserRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import stackpot.stackpot.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/stackpot/stackpot/service/CustomUserDetailService.java
+++ b/src/main/java/stackpot/stackpot/service/CustomUserDetailService.java
@@ -1,0 +1,25 @@
+package stackpot.stackpot.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import stackpot.stackpot.domain.User;
+import stackpot.stackpot.repository.UserRepository.UserRepository;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        // UserDetails 반환
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/stackpot/stackpot/service/JwtUserDetailsService.java
+++ b/src/main/java/stackpot/stackpot/service/JwtUserDetailsService.java
@@ -1,0 +1,4 @@
+package stackpot.stackpot.service;
+
+public class JwtUserDetailsService {
+}

--- a/src/main/java/stackpot/stackpot/service/UserCommandService.java
+++ b/src/main/java/stackpot/stackpot/service/UserCommandService.java
@@ -1,0 +1,9 @@
+package stackpot.stackpot.service;
+
+import stackpot.stackpot.domain.User;
+import stackpot.stackpot.web.dto.UserRequestDTO;
+
+public interface UserCommandService {
+
+    public User joinUser(UserRequestDTO.JoinDto request);
+}

--- a/src/main/java/stackpot/stackpot/service/UserCommandServiceImpl.java
+++ b/src/main/java/stackpot/stackpot/service/UserCommandServiceImpl.java
@@ -1,0 +1,24 @@
+package stackpot.stackpot.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import stackpot.stackpot.converter.UserConverter;
+import stackpot.stackpot.domain.User;
+import stackpot.stackpot.repository.UserRepository.UserRepository;
+import stackpot.stackpot.web.dto.UserRequestDTO;
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandServiceImpl implements UserCommandService{
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public User joinUser(UserRequestDTO.JoinDto request) {
+
+        User newUser = UserConverter.toUser(request);
+        return userRepository.save(newUser);
+    }
+}

--- a/src/main/java/stackpot/stackpot/web/controller/MemberViewController.java
+++ b/src/main/java/stackpot/stackpot/web/controller/MemberViewController.java
@@ -1,0 +1,2 @@
+package stackpot.stackpot.web.controller;public class MemberViewController {
+}

--- a/src/main/java/stackpot/stackpot/web/controller/MemberViewController.java
+++ b/src/main/java/stackpot/stackpot/web/controller/MemberViewController.java
@@ -1,13 +1,14 @@
 package stackpot.stackpot.web.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestHeader;
+import stackpot.stackpot.config.security.JwtTokenProvider;
 import stackpot.stackpot.service.UserCommandService;
 import stackpot.stackpot.web.dto.UserRequestDTO;
 
@@ -16,34 +17,48 @@ import stackpot.stackpot.web.dto.UserRequestDTO;
 public class MemberViewController {
 
     private final UserCommandService userCommandService;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    @PostMapping("/user/profile")
-    public String joinUser(@ModelAttribute("UserJoinDto") UserRequestDTO.JoinDto request,
-                           BindingResult bindingResult,
-                           Model model) {
-        if (bindingResult.hasErrors()) {
-            return "signup";
-        }
-
-        try {
-            userCommandService.joinUser(request);
-            return "redirect:/login";
-        } catch (Exception e) {
-            model.addAttribute("error", e.getMessage());
-            return "signup";
-        }
-    }
-
+    // 로그인 페이지
     @GetMapping("/login")
     public String loginPage() {
         return "login";
     }
 
-    @GetMapping("/user/profile")
-    public String signupPage(@RequestParam(required = false) String email, Model model) {
-        model.addAttribute("email", email); // 카카오 이메일 전달
+//     회원가입 페이지 랜더링
+    @GetMapping("/signup")
+    public String signupPage() {
+        // 단순히 회원가입 페이지를 렌더링
         return "signup";
     }
 
+    // 회원가입 처리
+    @PostMapping("/user/signup")
+    public String joinUser(@Valid @ModelAttribute("UserJoinDTO") UserRequestDTO.JoinDto request,
+                           BindingResult bindingResult,
+                           @RequestHeader(value = "Authorization", required = false) String token,
+                           Model model) {
+        if (bindingResult.hasErrors()) {
+            return "signup"; // 유효성 검사 실패 시 다시 회원가입 페이지로
+        }
 
+        try {
+            if (token == null || !token.startsWith("Bearer ")) {
+                throw new IllegalArgumentException("Authorization header is missing or invalid.");
+            }
+
+            // JWT에서 이메일 추출
+            String email = jwtTokenProvider.getEmailFromToken(token.replace("Bearer ", ""));
+            request.setEmail(email); // DTO에 이메일 설정
+            System.out.println("Extracted Email: " + email);
+
+
+            // 회원가입 처리
+            userCommandService.joinUser(request);
+            return "redirect:/home"; // 성공 시 홈 페이지로 리다이렉트
+        } catch (Exception e) {
+            model.addAttribute("error", e.getMessage());
+            return "signup"; // 에러 발생 시 다시 회원가입 페이지로
+        }
+    }
 }

--- a/src/main/java/stackpot/stackpot/web/controller/MemberViewController.java
+++ b/src/main/java/stackpot/stackpot/web/controller/MemberViewController.java
@@ -1,20 +1,49 @@
 package stackpot.stackpot.web.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import stackpot.stackpot.service.UserCommandService;
+import stackpot.stackpot.web.dto.UserRequestDTO;
 
 @Controller
+@RequiredArgsConstructor
 public class MemberViewController {
+
+    private final UserCommandService userCommandService;
+
+    @PostMapping("/user/profile")
+    public String joinUser(@ModelAttribute("UserJoinDto") UserRequestDTO.JoinDto request,
+                           BindingResult bindingResult,
+                           Model model) {
+        if (bindingResult.hasErrors()) {
+            return "signup";
+        }
+
+        try {
+            userCommandService.joinUser(request);
+            return "redirect:/login";
+        } catch (Exception e) {
+            model.addAttribute("error", e.getMessage());
+            return "signup";
+        }
+    }
+
     @GetMapping("/login")
     public String loginPage() {
         return "login";
     }
 
-    @GetMapping("/signup")
-    public String signupPage(Model model) {
-//        model.addAttribute("memberJoinDto", new MemberRequestDTO.JoinDto());
+    @GetMapping("/user/profile")
+    public String signupPage(@RequestParam(required = false) String email, Model model) {
+        model.addAttribute("email", email); // 카카오 이메일 전달
         return "signup";
     }
+
 
 }

--- a/src/main/java/stackpot/stackpot/web/controller/MemberViewController.java
+++ b/src/main/java/stackpot/stackpot/web/controller/MemberViewController.java
@@ -1,2 +1,19 @@
-package stackpot.stackpot.web.controller;public class MemberViewController {
+package stackpot.stackpot.web.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MemberViewController {
+    @GetMapping("/login")
+    public String loginPage() {
+        return "login";
+    }
+    @GetMapping("/signup")
+    public String signupPage(Model model) {
+//        model.addAttribute("memberJoinDto", new MemberRequestDTO.JoinDto());
+        return "signup";
+    }
+
 }

--- a/src/main/java/stackpot/stackpot/web/controller/MemberViewController.java
+++ b/src/main/java/stackpot/stackpot/web/controller/MemberViewController.java
@@ -10,6 +10,7 @@ public class MemberViewController {
     public String loginPage() {
         return "login";
     }
+
     @GetMapping("/signup")
     public String signupPage(Model model) {
 //        model.addAttribute("memberJoinDto", new MemberRequestDTO.JoinDto());

--- a/src/main/java/stackpot/stackpot/web/controller/MemberViewController.java
+++ b/src/main/java/stackpot/stackpot/web/controller/MemberViewController.java
@@ -25,7 +25,7 @@ public class MemberViewController {
         return "login";
     }
 
-//     회원가입 페이지 랜더링
+    // 회원가입 페이지 랜더링
     @GetMapping("/signup")
     public String signupPage() {
         // 단순히 회원가입 페이지를 렌더링
@@ -33,6 +33,7 @@ public class MemberViewController {
     }
 
     // 회원가입 처리
+    // 미완성
     @PostMapping("/user/signup")
     public String joinUser(@Valid @ModelAttribute("UserJoinDTO") UserRequestDTO.JoinDto request,
                            BindingResult bindingResult,

--- a/src/main/java/stackpot/stackpot/web/controller/UserController.java
+++ b/src/main/java/stackpot/stackpot/web/controller/UserController.java
@@ -1,0 +1,11 @@
+package stackpot.stackpot.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+}

--- a/src/main/java/stackpot/stackpot/web/dto/JwtDto.java
+++ b/src/main/java/stackpot/stackpot/web/dto/JwtDto.java
@@ -1,0 +1,5 @@
+package stackpot.stackpot.web.dto;
+
+public record JwtDto(String accessToken,
+                     String refreshToken) {
+}

--- a/src/main/java/stackpot/stackpot/web/dto/JwtDto.java
+++ b/src/main/java/stackpot/stackpot/web/dto/JwtDto.java
@@ -1,5 +1,0 @@
-package stackpot.stackpot.web.dto;
-
-public record JwtDto(String accessToken,
-                     String refreshToken) {
-}

--- a/src/main/java/stackpot/stackpot/web/dto/LoginResponseDTO.java
+++ b/src/main/java/stackpot/stackpot/web/dto/LoginResponseDTO.java
@@ -1,4 +1,0 @@
-package stackpot.stackpot.web.dto;
-
-public class LoginResponseDTO {
-}

--- a/src/main/java/stackpot/stackpot/web/dto/LoginResponseDTO.java
+++ b/src/main/java/stackpot/stackpot/web/dto/LoginResponseDTO.java
@@ -1,0 +1,4 @@
+package stackpot.stackpot.web.dto;
+
+public class LoginResponseDTO {
+}

--- a/src/main/java/stackpot/stackpot/web/dto/UserRequestDTO.java
+++ b/src/main/java/stackpot/stackpot/web/dto/UserRequestDTO.java
@@ -15,7 +15,7 @@ public class UserRequestDTO {
     @Setter
     public static class JoinDto {
         @NotNull
-        Role role;
+        String role;
         @NotNull
         String interest;
         @NotBlank

--- a/src/main/java/stackpot/stackpot/web/dto/UserRequestDTO.java
+++ b/src/main/java/stackpot/stackpot/web/dto/UserRequestDTO.java
@@ -1,0 +1,30 @@
+package stackpot.stackpot.web.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.management.relation.Role;
+
+public class UserRequestDTO {
+
+    @Getter
+    @Setter
+    public static class JoinDto {
+        @NotNull
+        Role role;
+        @NotNull
+        String interest;
+        @NotBlank
+        String nickname;
+        @NotBlank
+        @Email
+        String email; // 이메일
+        @NotNull
+        String kakaoId; // 카카오 아이디
+
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,7 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET}
             redirect-uri: http://localhost:8080/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
-            scope: profile_nickname
+            scope: account_email
             client-name: Kakao
         provider:
           kakao:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,8 +36,8 @@ spring:
         registration:
           kakao:
             client-authentication-method: client_secret_post
-            client-id: d84efa2760475c897588429fbac5d1e6
-            client-secret: Kz1nktBgxUxKYEIlGz2kmwHIGkxRggY3
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
             redirect-uri: http://localhost:8080/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
             scope: profile_nickname

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,21 @@ spring:
       credentials:
         accessKey: ${AWS_ACCESS_KEY_ID}
         secretKey: ${AWS_SECRET_ACCESS_KEY}
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-authentication-method: client_secret_post
+            client-id: d84efa2760475c897588429fbac5d1e6
+            client-secret: Kz1nktBgxUxKYEIlGz2kmwHIGkxRggY3
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            scope: profile_nickname
+            client-name: Kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Home</title>
+</head>
+<body>
+<h2>Welcome to Home Page!</h2>
+<p th:text="'반가워, ' + ${#authentication.name} + '!'"></p>
+<!-- 관리자 권한이 있을 때만 관리자 페이지 버튼 표시 -->
+<div th:if="${#authorization.expression('hasRole(''ADMIN'')')}">
+    <a th:href="@{/admin}">관리자 페이지로 이동</a>
+</div>
+<!-- 로그아웃 버튼 추가 -->
+<form th:action="@{/logout}" method="post">
+    <button type="submit">Logout</button>
+</form>
+</body>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Login</title>
+</head>
+<body>
+<a th:href="@{/oauth2/authorization/kakao}">카카오로 로그인</a>
+
+<p th:if="${param.error}">사용자 이름 또는 비밀번호가 잘못되었습니다.</p>
+<p th:if="${param.logout}">로그아웃되었습니다.</p>
+<!-- 회원가입 링크 수정 -->
+<p>계정이 없나요? <a th:href="@{/signup}">Sign up</a></p>
+</body>
+</html>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>회원가입</title>
+    <style>
+        /* 기존 스타일 유지 */
+    </style>
+</head>
+<body>
+<h2>회원가입</h2>
+<form th:action="@{/user/signup}" th:object="${UserJoinDTO}" method="post">
+    <div th:if="${error}" th:text="${error}" style="color: red;"></div>
+    <button type="submit">가입하기</button>
+</form>
+</body>
+</html>

--- a/src/test/java/stackpot/stackpot/controller/MemberViewControllerTest.java
+++ b/src/test/java/stackpot/stackpot/controller/MemberViewControllerTest.java
@@ -1,0 +1,51 @@
+package stackpot.stackpot.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import stackpot.stackpot.service.UserCommandService;
+import stackpot.stackpot.web.controller.MemberViewController;
+import stackpot.stackpot.web.dto.UserRequestDTO;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(MemberViewController.class)
+class MemberViewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserCommandService userCommandService;
+
+    @Test
+    void testJoinUser_Success() throws Exception {
+        // Mock request data
+        UserRequestDTO.JoinDto joinDto = new UserRequestDTO.JoinDto();
+        joinDto.setEmail("test@example.com");
+        joinDto.setNickname("TestUser");
+        joinDto.setKakaoId("12345");
+
+        doNothing().when(userCommandService).joinUser(any(UserRequestDTO.JoinDto.class));
+
+        mockMvc.perform(post("/user/profile")
+                        .flashAttr("UserJoinDto", joinDto))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/login"));
+    }
+
+    @Test
+    void testJoinUser_ValidationError() throws Exception {
+        mockMvc.perform(post("/user/profile")
+                        .param("email", "") // 잘못된 데이터
+                        .param("nickname", "")
+                        .param("kakaoId", ""))
+                .andExpect(status().isOk())
+                .andExpect(view().name("signup"))
+                .andExpect(model().attributeExists("error"));
+    }
+}

--- a/src/test/java/stackpot/stackpot/controller/MemberViewControllerTest.java
+++ b/src/test/java/stackpot/stackpot/controller/MemberViewControllerTest.java
@@ -1,51 +1,51 @@
-package stackpot.stackpot.controller;
-
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
-import stackpot.stackpot.service.UserCommandService;
-import stackpot.stackpot.web.controller.MemberViewController;
-import stackpot.stackpot.web.dto.UserRequestDTO;
-
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-@WebMvcTest(MemberViewController.class)
-class MemberViewControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private UserCommandService userCommandService;
-
-    @Test
-    void testJoinUser_Success() throws Exception {
-        // Mock request data
-        UserRequestDTO.JoinDto joinDto = new UserRequestDTO.JoinDto();
-        joinDto.setEmail("test@example.com");
-        joinDto.setNickname("TestUser");
-        joinDto.setKakaoId("12345");
-
-        doNothing().when(userCommandService).joinUser(any(UserRequestDTO.JoinDto.class));
-
-        mockMvc.perform(post("/user/profile")
-                        .flashAttr("UserJoinDto", joinDto))
-                .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/login"));
-    }
-
-    @Test
-    void testJoinUser_ValidationError() throws Exception {
-        mockMvc.perform(post("/user/profile")
-                        .param("email", "") // 잘못된 데이터
-                        .param("nickname", "")
-                        .param("kakaoId", ""))
-                .andExpect(status().isOk())
-                .andExpect(view().name("signup"))
-                .andExpect(model().attributeExists("error"));
-    }
-}
+//package stackpot.stackpot.controller;
+//
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+//import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.test.web.servlet.MockMvc;
+//import stackpot.stackpot.service.UserCommandService;
+//import stackpot.stackpot.web.controller.MemberViewController;
+//import stackpot.stackpot.web.dto.UserRequestDTO;
+//
+//import static org.mockito.Mockito.*;
+//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+//
+//@WebMvcTest(MemberViewController.class)
+//class MemberViewControllerTest {
+//
+//    @Autowired
+//    private MockMvc mockMvc;
+//
+//    @MockBean
+//    private UserCommandService userCommandService;
+//
+//    @Test
+//    void testJoinUser_Success() throws Exception {
+//        // Mock request data
+//        UserRequestDTO.JoinDto joinDto = new UserRequestDTO.JoinDto();
+//        joinDto.setEmail("test@example.com");
+//        joinDto.setNickname("TestUser");
+//        joinDto.setKakaoId("12345");
+//
+//        doNothing().when(userCommandService).joinUser(any(UserRequestDTO.JoinDto.class));
+//
+//        mockMvc.perform(post("/user/profile")
+//                        .flashAttr("UserJoinDto", joinDto))
+//                .andExpect(status().is3xxRedirection())
+//                .andExpect(redirectedUrl("/login"));
+//    }
+//
+//    @Test
+//    void testJoinUser_ValidationError() throws Exception {
+//        mockMvc.perform(post("/user/profile")
+//                        .param("email", "") // 잘못된 데이터
+//                        .param("nickname", "")
+//                        .param("kakaoId", ""))
+//                .andExpect(status().isOk())
+//                .andExpect(view().name("signup"))
+//                .andExpect(model().attributeExists("error"));
+//    }
+//}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[ x ] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#9 -> dev

### 작업 내용
### 소셜 로그인

카카오 로그인 

- 카카오 로그인을 통한 정보
- 카카오 이메일

소셜 로그인 로직 

`code` → `access_token` → `사용자 정보`

→ api 요청 수정 필요 ( 테스트를 위해 login 으로 경로 설정 ) 

- 회원가입 흐름
    
    로그인  → 이메일 탐색 → 없을 시 회원가입 페이지로 리다이렉트
    

### 토큰 발급

- JWT 토큰 방식
- 현재 토큰에는 email 정보만 들어있음
- 추가

src/main/java/
└── com/example/projectname
├── config
 │   ├── security
 │      ├── JwtTokenProvider.java      # JWT 생성 및 검증 클래스
 │      ├── JwtTokenFilter.java        # JWT 필터 클래스
 │      └── SecurityConfig.java        # Spring Security 설정
├── domain
 │   └── User.java                      # 사용자 엔티티 클래스 ← 인터페이스 추가 구현
├── repository
 │   └── UserRepository.java            # 사용자 저장소 인터페이스
├── service
 │   ├── CustomUserDetailService             # 사용자 서비스 인터페이스


