### PR TITLE
[FEAT] feed 좋아요 여부 추가, cursor 수정

### DIFF
--- a/src/main/java/stackpot/stackpot/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/stackpot/stackpot/config/security/JwtAuthenticationFilter.java
@@ -4,6 +4,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.security.core.Authentication;
@@ -11,13 +13,11 @@ import stackpot.stackpot.repository.BlacklistRepository;
 import stackpot.stackpot.repository.UserRepository.UserRepository;
 
 import java.io.IOException;
+import java.util.Collections;
+
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
-
-//    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
-//           this.jwtTokenProvider = jwtTokenProvider;
-//   }
 
 private final BlacklistRepository blacklistRepository;
 
@@ -52,14 +52,22 @@ private final BlacklistRepository blacklistRepository;
                     return;
                 }
             } else {
-                System.out.println("No token found in the request.");
+                // 토큰이 없는 경우 AnonymousAuthenticationToken 설정 (비로그인 요청 정상 처리)
+                System.out.println("🔹 토큰이 없음, 비로그인 요청 처리");
+                Authentication anonymousAuth = new AnonymousAuthenticationToken(
+                        "anonymousUser",
+                        "anonymousUser",
+                        Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
+                );
+                SecurityContextHolder.getContext().setAuthentication(anonymousAuth);
+//                System.out.println("✅ SecurityContext에 AnonymousAuthenticationToken 저장됨");
             }
-            filterChain.doFilter(request, response);
         } catch (Exception ex) {
             System.out.println("Exception in JwtAuthenticationFilter: " + ex.getMessage());
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             response.getWriter().write("Internal server error occurred.");
         }
+        filterChain.doFilter(request, response);
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
+++ b/src/main/java/stackpot/stackpot/config/security/SecurityConfig.java
@@ -42,7 +42,6 @@ public class SecurityConfig {
                         .requestMatchers("/", "/home","/sign-up", "/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs/**", "/users/oauth/kakao", "/pots", "/feeds","/reissue").permitAll()
                         .anyRequest().authenticated()
                 )
-//                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, blacklistRepository), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/src/main/java/stackpot/stackpot/repository/FeedLikeRepository.java
+++ b/src/main/java/stackpot/stackpot/repository/FeedLikeRepository.java
@@ -8,6 +8,7 @@ import stackpot.stackpot.domain.Feed;
 import stackpot.stackpot.domain.User;
 import stackpot.stackpot.domain.mapping.FeedLike;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -19,4 +20,8 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
     // 특정 게시물의 좋아요 개수 조회
     @Query("SELECT COUNT(fl) FROM FeedLike fl WHERE fl.feed = :feed")
     Long countByFeed(@Param("feed") Feed feed);
+
+    @Query("SELECT fl.feed.id FROM FeedLike fl WHERE fl.user.id = :userId")
+    List<Long> findFeedIdsByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/stackpot/stackpot/service/FeedService.java
+++ b/src/main/java/stackpot/stackpot/service/FeedService.java
@@ -9,7 +9,6 @@ public interface FeedService {
      FeedResponseDto.FeedPreviewList getPreViewFeeds(String category, String sort, Long cursor, int limit);
      Feed createFeed(FeedRequestDto.createDto request);
 
-
      Feed getFeed(Long feedId);
      FeedResponseDto.FeedPreviewList getFeedsByUserId(Long userId, Long nextCursor, int pageSize);
      FeedResponseDto.FeedPreviewList getFeeds(Long nextCursor, int pageSize);

--- a/src/main/java/stackpot/stackpot/service/UserCommandServiceImpl.java
+++ b/src/main/java/stackpot/stackpot/service/UserCommandServiceImpl.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class UserCommandServiceImpl implements UserCommandService{
+public class UserCommandServiceImpl implements UserCommandService {
 
     private final UserRepository userRepository;
     private final PotRepository potRepository;
@@ -79,17 +79,24 @@ public class UserCommandServiceImpl implements UserCommandService{
         // 이메일로 기존 유저 조회
         Optional<User> existingUser = userRepository.findByEmail(email);
 
-        if (existingUser.isPresent() && !existingUser.get().getNickname().isEmpty()) {
-            // 기존 유저가 있으면 isNewUser = false
-            User user = existingUser.get();
-            log.info("사용자의 닉네임 : {}", existingUser.get().getNickname());
-            TokenServiceResponse token = jwtTokenProvider.createToken(user);
+        if (existingUser.isPresent()) {
+            String checkNickname = existingUser.get().getNickname();
+            if (checkNickname != null) {
+                // 기존 유저가 있으면 isNewUser = false
+                User user = existingUser.get();
+                log.info("사용자의 닉네임 : {}", existingUser.get().getNickname());
+                TokenServiceResponse token = jwtTokenProvider.createToken(user);
 
-            return UserResponseDto.loginDto.builder()
-                    .tokenServiceResponse(token)
-                    .isNewUser(false)
-                    .build();
-        } else {
+                return UserResponseDto.loginDto.builder()
+                        .tokenServiceResponse(token)
+                        .isNewUser(false)
+                        .build();
+            } else {
+                User user = existingUser.get();
+                userRepository.delete(user);
+            }
+
+        }
             // 신규 유저 생성
             User newUser = User.builder()
                     .email(email)
@@ -103,7 +110,6 @@ public class UserCommandServiceImpl implements UserCommandService{
                     .tokenServiceResponse(token)
                     .isNewUser(true)  // 신규 유저임을 표시
                     .build();
-        }
     }
 
 

--- a/src/main/java/stackpot/stackpot/web/dto/FeedResponseDto.java
+++ b/src/main/java/stackpot/stackpot/web/dto/FeedResponseDto.java
@@ -28,10 +28,10 @@ public class FeedResponseDto {
         private Long writerId;
         private String writer;
         private Role writerRole;
-//        private Category category;
         private String title;
         private String content;
         private Long likeCount;
+        private Boolean isLiked;
         private String createdAt;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,6 @@ spring:
       enabled: true
   data:
     redis:
-      host: redis-container
-#      host: localhost
+#      host: redis-container
+      host: localhost
       port: 6379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,6 @@ spring:
       enabled: true
   data:
     redis:
-#      host: redis-container
-      host: localhost
+      host: redis-container
+#      host: localhost
       port: 6379


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[x] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
rudeore0928/main -> dev

### 작업 내용
feed 조회 시 로그인된 유저가 좋아요를 눌렀는지에 대한 여부를 dto에 추가했습니다.
-> feedpreview의 경우 비로그인 회원도 볼 수 있기에 로그인 유무를 판단하는 로직도 추가하였습니다.

남은 피드가 없다면 cursor가 null을 반환하도록 수정하였습니다.

