### PR TITLE
[REFACTOR] 인증 로직을 AuthService로 분리하여 중복 제거

### DIFF
--- a/src/main/java/stackpot/stackpot/common/util/AuthService.java
+++ b/src/main/java/stackpot/stackpot/common/util/AuthService.java
@@ -1,0 +1,43 @@
+package stackpot.stackpot.common.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import stackpot.stackpot.apiPayload.code.status.ErrorStatus;
+import stackpot.stackpot.apiPayload.exception.handler.MemberHandler;
+import stackpot.stackpot.user.entity.User;
+import stackpot.stackpot.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+
+    public User getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getName() == null) {
+            throw new MemberHandler(ErrorStatus.AUTHENTICATION_FAILED);
+        }
+
+        String email = authentication.getName();
+
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    public Long getCurrentUserId() {
+        return getCurrentUser().getId();
+    }
+
+    public String getCurrentUserEmail() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            throw new MemberHandler(ErrorStatus.AUTHENTICATION_FAILED);
+        }
+        return authentication.getName();
+    }
+}
+


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[✅] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
refactor/auth-service-context-extraction -> dev

### 작업 내용
인증 로직을 AuthService로 분리하여 유틸화하였습니다.

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
