### PR TITLE
[FEAT/#299] Swagger에 커스텀 에러 응답 예제 적용 및 예외 응답 구조 개선

### DIFF
--- a/src/main/java/stackpot/stackpot/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/stackpot/stackpot/apiPayload/code/ErrorReasonDTO.java
@@ -13,5 +13,10 @@ public class ErrorReasonDTO {
     private final String code;
     private final String message;
 
+
+
     public boolean getIsSuccess(){return isSuccess;}
+    public static ErrorReasonDTO of(HttpStatus status, String code, String message) {
+        return new ErrorReasonDTO(status, false, code, message);
+    }
 }

--- a/src/main/java/stackpot/stackpot/apiPayload/code/ErrorResponseDto.java
+++ b/src/main/java/stackpot/stackpot/apiPayload/code/ErrorResponseDto.java
@@ -1,0 +1,40 @@
+package stackpot.stackpot.apiPayload.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import stackpot.stackpot.apiPayload.code.status.ErrorStatus;
+
+
+@Getter
+
+public class ErrorResponseDto extends ErrorReasonDTO {
+
+    private ErrorResponseDto(HttpStatus httpStatus, String code, String message) {
+        super(httpStatus, false, code, message);
+    }
+
+    public static ErrorResponseDto of(ErrorStatus errorStatus) {
+        return new ErrorResponseDto(
+                errorStatus.getHttpStatus(),
+                errorStatus.getCode(),
+                errorStatus.getMessage()
+        );
+    }
+
+    public static ErrorResponseDto of(ErrorStatus errorStatus, String message) {
+        return new ErrorResponseDto(
+                errorStatus.getHttpStatus(),
+                errorStatus.getCode(),
+                errorStatus.getMessage() + " - " + message
+        );
+    }
+
+    public static ErrorResponseDto of(ErrorStatus errorStatus, Exception e) {
+        return new ErrorResponseDto(
+                errorStatus.getHttpStatus(),
+                errorStatus.getCode(),
+                errorStatus.getMessage() // 예외 메시지를 포함하려면 따로 가공 필요
+        );
+    }
+}

--- a/src/main/java/stackpot/stackpot/apiPayload/code/ReasonDTO.java
+++ b/src/main/java/stackpot/stackpot/apiPayload/code/ReasonDTO.java
@@ -13,4 +13,5 @@ public class ReasonDTO {
     private final String message;
 
     public boolean getIsSuccess(){return isSuccess;}
+
 }

--- a/src/main/java/stackpot/stackpot/common/swagger/ApiErrorCodeExample.java
+++ b/src/main/java/stackpot/stackpot/common/swagger/ApiErrorCodeExample.java
@@ -1,0 +1,15 @@
+package stackpot.stackpot.common.swagger;
+
+import stackpot.stackpot.apiPayload.code.status.ErrorStatus;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExample {
+
+    ErrorStatus value();
+}

--- a/src/main/java/stackpot/stackpot/common/swagger/ApiErrorCodeExamples.java
+++ b/src/main/java/stackpot/stackpot/common/swagger/ApiErrorCodeExamples.java
@@ -1,0 +1,14 @@
+package stackpot.stackpot.common.swagger;
+
+import stackpot.stackpot.apiPayload.code.status.ErrorStatus;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.Retention;
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExamples {
+
+    ErrorStatus[] value();
+}

--- a/src/main/java/stackpot/stackpot/common/swagger/ExampleHolder.java
+++ b/src/main/java/stackpot/stackpot/common/swagger/ExampleHolder.java
@@ -1,0 +1,14 @@
+package stackpot.stackpot.common.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+    private Example holder;
+    private String name;
+    private int code;
+}

--- a/src/main/java/stackpot/stackpot/config/SwaggerConfig.java
+++ b/src/main/java/stackpot/stackpot/config/SwaggerConfig.java
@@ -1,14 +1,30 @@
 package stackpot.stackpot.config;
 
+
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
+import stackpot.stackpot.apiPayload.code.ErrorResponseDto;
+import stackpot.stackpot.apiPayload.code.status.ErrorStatus;
+import stackpot.stackpot.common.swagger.ApiErrorCodeExample;
+import stackpot.stackpot.common.swagger.ApiErrorCodeExamples;
+import stackpot.stackpot.common.swagger.ExampleHolder;
+import io.swagger.v3.oas.models.Operation;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 
 @Configuration
@@ -42,4 +58,82 @@ public class SwaggerConfig {
                 .addSecurityItem(securityRequirement) // SecurityRequirement 추가
                 .components(components); // SecuritySchemes 등록
     }
+
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (operation, handlerMethod) -> {
+            ApiErrorCodeExamples errorCodeExamples = handlerMethod.getMethodAnnotation(ApiErrorCodeExamples.class);
+            if (errorCodeExamples != null) {
+                generateErrorCodeResponseExample(operation, errorCodeExamples.value());
+            }
+
+            ApiErrorCodeExample errorCodeExample = handlerMethod.getMethodAnnotation(ApiErrorCodeExample.class);
+            if (errorCodeExample != null) {
+                generateErrorCodeResponseExample(operation, errorCodeExample.value());
+            }
+
+            return operation;
+        };
+    }
+
+    private void generateErrorCodeResponseExample(Operation operation, ErrorStatus[] errorStatuses) {
+        ApiResponses responses = operation.getResponses();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders = Arrays.stream(errorStatuses)
+                .map(errorStatus -> ExampleHolder.builder()
+                        .holder(getSwaggerExample(errorStatus))
+                        .code(errorStatus.getHttpStatus().value())
+                        .name(errorStatus.name())
+                        .build())
+                .collect(Collectors.groupingBy(ExampleHolder::getCode));
+
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private void generateErrorCodeResponseExample(Operation operation, ErrorStatus errorStatus) {
+        ApiResponses responses = operation.getResponses();
+        ExampleHolder exampleHolder = ExampleHolder.builder()
+                .holder(getSwaggerExample(errorStatus))
+                .name(errorStatus.name())
+                .code(errorStatus.getHttpStatus().value())
+                .build();
+        addExamplesToResponses(responses, exampleHolder);
+    }
+
+    private Example getSwaggerExample(ErrorStatus errorStatus) {
+        // ✅ ErrorReasonDTO를 상속한 ErrorResponseDto 기반으로 예시 작성
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.of(errorStatus);
+
+        Example example = new Example();
+        example.setValue(errorResponseDto); // 자동 직렬화되어 Swagger UI에 보여짐
+        return example;
+    }
+
+    private void addExamplesToResponses(ApiResponses responses,
+                                        Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach((status, holders) -> {
+            Content content = new Content();
+            MediaType mediaType = new MediaType();
+            ApiResponse apiResponse = new ApiResponse();
+
+            holders.forEach(holder -> mediaType.addExamples(holder.getName(), holder.getHolder()));
+            content.addMediaType("application/json", mediaType);
+            apiResponse.setContent(content);
+            responses.addApiResponse(String.valueOf(status), apiResponse);
+        });
+    }
+
+    private void addExamplesToResponses(ApiResponses responses, ExampleHolder exampleHolder) {
+        Content content = new Content();
+        MediaType mediaType = new MediaType();
+        ApiResponse apiResponse = new ApiResponse();
+
+        mediaType.addExamples(exampleHolder.getName(), exampleHolder.getHolder());
+        content.addMediaType("application/json", mediaType);
+        apiResponse.setContent(content);
+        responses.addApiResponse(String.valueOf(exampleHolder.getCode()), apiResponse);
+    }
+
+
 }

--- a/src/main/java/stackpot/stackpot/pot/controller/PotApplicationController.java
+++ b/src/main/java/stackpot/stackpot/pot/controller/PotApplicationController.java
@@ -7,6 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import stackpot.stackpot.apiPayload.ApiResponse;
+import stackpot.stackpot.apiPayload.code.status.ErrorStatus;
+import stackpot.stackpot.common.swagger.ApiErrorCodeExample;
+import stackpot.stackpot.common.swagger.ApiErrorCodeExamples;
 import stackpot.stackpot.pot.dto.PotApplicationRequestDto;
 import stackpot.stackpot.pot.dto.PotApplicationResponseDto;
 import stackpot.stackpot.pot.service.PotApplicationCommandService;
@@ -23,17 +26,24 @@ public class PotApplicationController {
     private final PotApplicationCommandService potApplicationCommandService;
     private final PotApplicationQueryService potApplicationQueryService;
     @Operation(summary = "팟 지원 API")
+    @ApiErrorCodeExamples({
+            ErrorStatus.POT_NOT_FOUND,
+            ErrorStatus.DUPLICATE_APPLICATION
+    })
     @PostMapping
     public ResponseEntity<ApiResponse<PotApplicationResponseDto>> applyToPot(
             @PathVariable("pot_id") Long potId,
             @RequestBody @Valid PotApplicationRequestDto requestDto) {
 
-        // 팟 지원 로직 호출
+
         PotApplicationResponseDto responseDto = potApplicationCommandService.applyToPot(requestDto, potId);
 
-        return ResponseEntity.ok(ApiResponse.onSuccess(responseDto)); // 성공 시 ApiResponse로 감싸서 응답 반환
+        return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
     }
     @Operation(summary = "팟 지원 취소 API")
+    @ApiErrorCodeExamples({
+            ErrorStatus.APPLICATION_NOT_FOUND
+    })
     @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> cancelApplication(@PathVariable("pot_id") Long potId) {
         potApplicationCommandService.cancelApplication(potId);
@@ -42,13 +52,16 @@ public class PotApplicationController {
 
 
     @Operation(summary = "팟 지원자 조회 API")
+    @ApiErrorCodeExamples({
+            ErrorStatus.UNAUTHORIZED_ACCESS
+    })
     @GetMapping("")
     public ResponseEntity<ApiResponse<List<PotApplicationResponseDto>>> getApplicants(
             @PathVariable("pot_id") Long potId) {
         // 서비스 호출
         List<PotApplicationResponseDto> applicants = potApplicationQueryService.getApplicantsByPotId(potId);
 
-        return ResponseEntity.ok(ApiResponse.onSuccess(applicants)); // 성공 시 ApiResponse로 감싸서 응답 반환
+        return ResponseEntity.ok(ApiResponse.onSuccess(applicants));
     }
 
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[✅] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
refactor/pot-cqrs-structure -> dev

### 작업 내용
Swagger 문서에 커스텀 에러 코드 예시를 자동으로 반영하는 기능을 추가했습니다.

### 테스트 결과
![image](https://github.com/user-attachments/assets/c154672f-ef1f-4dd4-b761-683c1b75f901)


관련 이슈: #299 