### PR TITLE
[FIX] ::set-output 말고 ssh 내에선 그냥 echo하면 자동으로 인식

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,7 +43,7 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             PORT=$(sudo grep -oP 'server 127\.0\.0\.1:\K\d+' /etc/nginx/sites-available/default | head -n 1)
-            echo "::set-output name=stdout::$PORT"
+            echo "$PORT"
 
       - name: Set Target Version
         run: |


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩터링

### 반영 브랜치
bug/#369-cicd -> dev

### 작업 내용
::set-output 말고 ssh 내에선 그냥 echo하면 자동으로 인식

### 테스트 결과
