### PR TITLE
[Merge/#413] todo badge pot rename

### DIFF
--- a/src/main/java/stackpot/stackpot/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/stackpot/stackpot/apiPayload/code/status/ErrorStatus.java
@@ -75,7 +75,8 @@ public enum ErrorStatus implements BaseErrorCode {
     // Badge 관련 에러
     BADGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BADGE4004", "해당 BADGE를 찾을 수 없습니다."),
     BADGE_INSUFFICIENT_TOP_MEMBERS(HttpStatus.BAD_REQUEST, "BADGE4001", "팀원이 1명 이하라 뱃지 수여 조건을 만족하지 않습니다. 팀원은 최소 2명 이상이어야 합니다."),
-    BADGE_INSUFFICIENT_TODO_COUNTS(HttpStatus.BAD_REQUEST, "BADGE4002", "TODO를 완료한 사람이 2명 이하입니다."),
+    BADGE_INSUFFICIENT_TODO_COUNTS(HttpStatus.BAD_REQUEST, "BADGE4002", "TODO를 완료한 사람이 2명 미만입니다. 최소 2명 이상이어야 합니다."),
+
 
     // 검색 관련 에러
     INVALID_SEARCH_TYPE(HttpStatus.BAD_REQUEST, "SEARCH_STATUS4000", "검색 Type 형식이 올바르지 않습니다 (pot/feed)"),

--- a/src/main/java/stackpot/stackpot/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/stackpot/stackpot/apiPayload/code/status/ErrorStatus.java
@@ -75,7 +75,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // Badge 관련 에러
     BADGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BADGE4004", "해당 BADGE를 찾을 수 없습니다."),
     BADGE_INSUFFICIENT_TOP_MEMBERS(HttpStatus.BAD_REQUEST, "BADGE4001", "팀원이 1명 이하라 뱃지 수여 조건을 만족하지 않습니다. 팀원은 최소 2명 이상이어야 합니다."),
-    BADGE_INSUFFICIENT_TODO_COUNTS(HttpStatus.BAD_REQUEST, "BADGE4002", "TODO를 완료한 사람이 존재하지 않습니다."),
+    BADGE_INSUFFICIENT_TODO_COUNTS(HttpStatus.BAD_REQUEST, "BADGE4002", "TODO를 완료한 사람이 2명 이하입니다."),
 
     // 검색 관련 에러
     INVALID_SEARCH_TYPE(HttpStatus.BAD_REQUEST, "SEARCH_STATUS4000", "검색 Type 형식이 올바르지 않습니다 (pot/feed)"),

--- a/src/main/java/stackpot/stackpot/badge/controller/PotBadgeMemberController.java
+++ b/src/main/java/stackpot/stackpot/badge/controller/PotBadgeMemberController.java
@@ -37,7 +37,6 @@ public class PotBadgeMemberController {
     @Operation(summary = "팟에서 가장 많은 `투두를 완료한' 멤버에게 '할 일 정복자' 뱃지 부여")
     @PostMapping("/{potId}")
     @ApiErrorCodeExamples({
-            ErrorStatus.BADGE_NOT_FOUND,
             ErrorStatus.BADGE_INSUFFICIENT_TODO_COUNTS,
             ErrorStatus.POT_MEMBER_NOT_FOUND
     })

--- a/src/main/java/stackpot/stackpot/pot/controller/PotController.java
+++ b/src/main/java/stackpot/stackpot/pot/controller/PotController.java
@@ -152,4 +152,14 @@ public class PotController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
+    @Operation(summary = "팟 이름 수정 API")
+    @PatchMapping("/{pot_id}/rename")
+    public ResponseEntity<ApiResponse<String>> updatePotName(
+            @PathVariable Long pot_id,
+            @Valid @RequestBody PotNameUpdateRequestDto request
+    ) {
+        String res = potCommandService.updatePotName(pot_id, request);
+        return ResponseEntity.ok(ApiResponse.onSuccess(res));
+    }
+
 }

--- a/src/main/java/stackpot/stackpot/pot/dto/CompletedPotRequestDto.java
+++ b/src/main/java/stackpot/stackpot/pot/dto/CompletedPotRequestDto.java
@@ -15,7 +15,7 @@ public class CompletedPotRequestDto {
     @NotBlank(message = "팟 이름은 필수입니다.")
     private String potName;
 
-    private LocalDate potStartDate;
+    private String potStartDate;
 
     @NotBlank(message = "사용 언어는 필수입니다.")
     private String potLan;

--- a/src/main/java/stackpot/stackpot/pot/dto/PotNameUpdateRequestDto.java
+++ b/src/main/java/stackpot/stackpot/pot/dto/PotNameUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package stackpot.stackpot.pot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PotNameUpdateRequestDto {
+    private String potName;
+}

--- a/src/main/java/stackpot/stackpot/pot/entity/Pot.java
+++ b/src/main/java/stackpot/stackpot/pot/entity/Pot.java
@@ -38,6 +38,7 @@ public class Pot extends BaseEntity {
     @OneToMany(mappedBy = "pot", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<PotMember> potMembers;
 
+    @Setter
     @Column(nullable = false, length = 255)
     private String potName;
 

--- a/src/main/java/stackpot/stackpot/pot/repository/PotMemberRepository.java
+++ b/src/main/java/stackpot/stackpot/pot/repository/PotMemberRepository.java
@@ -51,8 +51,6 @@ public interface PotMemberRepository extends JpaRepository<PotMember, Long> {
     @Query("DELETE FROM PotMember pm WHERE pm.pot.potId = :potId")
     void deleteByPotId(@Param("potId") Long potId);
 
-    Optional<PotMember> findByPot_PotIdAndUser_Id(Long potId, Long userId);
-
     @Query("SELECT pm FROM PotMember pm WHERE pm.pot.potId = :potId AND pm.user.id = :userId")
     PotMember findByPotIdAndUserId(Long potId, Long userId);
 
@@ -94,4 +92,8 @@ public interface PotMemberRepository extends JpaRepository<PotMember, Long> {
     @Modifying
     @Query("DELETE FROM PotMember pm WHERE pm.pot.potId IN :potIds AND pm.user.id = :userId")
     void deleteByUserIdAndPotIdIn(@Param("userId") Long userId, @Param("potIds") List<Long> potIds);
+
+    long countByPot_PotId(Long potId);
+    Optional<PotMember> findByPot_PotIdAndUser_Id(Long potId, Long userId);
+
 }

--- a/src/main/java/stackpot/stackpot/pot/service/pot/PotCommandService.java
+++ b/src/main/java/stackpot/stackpot/pot/service/pot/PotCommandService.java
@@ -1,6 +1,7 @@
 package stackpot.stackpot.pot.service.pot;
 
 import stackpot.stackpot.pot.dto.CompletedPotRequestDto;
+import stackpot.stackpot.pot.dto.PotNameUpdateRequestDto;
 import stackpot.stackpot.pot.dto.PotRequestDto;
 import stackpot.stackpot.pot.dto.PotResponseDto;
 
@@ -19,4 +20,6 @@ public interface PotCommandService {
     void patchLikes(Long potId, Long applicationId, Boolean liked);
 
     PotResponseDto updateCompletedPot(Long potId, CompletedPotRequestDto requestDto);
+
+    String updatePotName(Long potId, PotNameUpdateRequestDto request);
 }

--- a/src/main/java/stackpot/stackpot/pot/service/pot/PotCommandServiceImpl.java
+++ b/src/main/java/stackpot/stackpot/pot/service/pot/PotCommandServiceImpl.java
@@ -19,10 +19,7 @@ import stackpot.stackpot.pot.converter.MyPotConverter;
 import stackpot.stackpot.pot.converter.PotConverter;
 import stackpot.stackpot.pot.converter.PotMemberConverter;
 import stackpot.stackpot.pot.converter.PotDetailConverter;
-import stackpot.stackpot.pot.dto.CompletedPotRequestDto;
-import stackpot.stackpot.pot.dto.PotRequestDto;
-import stackpot.stackpot.pot.dto.PotResponseDto;
-import stackpot.stackpot.pot.dto.RecruitingPotResponseDto;
+import stackpot.stackpot.pot.dto.*;
 import stackpot.stackpot.pot.entity.Pot;
 import stackpot.stackpot.pot.entity.PotRecruitmentDetails;
 import stackpot.stackpot.pot.entity.mapping.PotApplication;
@@ -41,6 +38,7 @@ import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 
@@ -197,7 +195,7 @@ public class PotCommandServiceImpl implements PotCommandService {
         Map<String, Object> updateValues = new LinkedHashMap<>();
         updateValues.put("potName", requestDto.getPotName());
         updateValues.put("potStartDate", requestDto.getPotStartDate());
-        updateValues.put("potEndDate", LocalDate.now());
+        updateValues.put("potEndDate", String.valueOf(LocalDate.now()));
         updateValues.put("potStatus", "COMPLETED");
         updateValues.put("potLan", requestDto.getPotLan());
         updateValues.put("potSummary", requestDto.getPotSummary());
@@ -271,5 +269,20 @@ public class PotCommandServiceImpl implements PotCommandService {
                 .collect(Collectors.toList());
 
         return potConverter.toDto(pot, recruitmentDetails);
+    }
+
+    @Override
+    @Transactional
+    public String updatePotName(Long potId, PotNameUpdateRequestDto request) {
+        User user = authService.getCurrentUser();
+        Pot pot = potRepository.findById(potId)
+                .orElseThrow(() -> new PotHandler(ErrorStatus.POT_NOT_FOUND));
+
+        if (!pot.getUser().equals(user)) {
+            throw new PotHandler(ErrorStatus.POT_FORBIDDEN);
+        }
+        pot.setPotName(request.getPotName());
+
+        return  pot.getPotName();
     }
 }

--- a/src/main/java/stackpot/stackpot/todo/repository/UserTodoRepository.java
+++ b/src/main/java/stackpot/stackpot/todo/repository/UserTodoRepository.java
@@ -1,5 +1,7 @@
 package stackpot.stackpot.todo.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,15 +11,11 @@ import stackpot.stackpot.todo.entity.enums.TodoStatus;
 import stackpot.stackpot.todo.entity.mapping.UserTodo;
 
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+
 
 @Repository
 public interface UserTodoRepository extends JpaRepository<UserTodo, Long> {
-
-    @Query("SELECT u.id " +
-            "FROM UserTodo t JOIN t.user u " +
-            "WHERE t.pot.potId = :potId AND t.status = :status " +
-            "GROUP BY u.id ORDER BY COUNT(t) DESC")
-    List<Long> findTop2UserIds(@Param("potId") Long potId, @Param("status") TodoStatus status);
 
     @Modifying
     @Query("DELETE FROM UserTodo f WHERE f.user.id = :userId")
@@ -28,5 +26,34 @@ public interface UserTodoRepository extends JpaRepository<UserTodo, Long> {
     void deleteByPotId(@Param("potId") Long potId);
 
     long countByPot_PotIdAndStatus(Long potPotId, TodoStatus status);
+
+    // 완료한 서로 다른 사용자 수 (distinct)
+    @Query("""
+        SELECT COUNT(DISTINCT ut.user.id)
+        FROM UserTodo ut
+        WHERE ut.pot.potId = :potId
+          AND ut.status = :status
+    """)
+    long countDistinctUserIdsByPotAndStatus(@Param("potId") Long potId,
+                                            @Param("status") TodoStatus status);
+
+    // 완료 개수 기준 상위 사용자 조회 (페이징 적용)
+    @Query("""
+        SELECT ut.user.id
+        FROM UserTodo ut
+        WHERE ut.pot.potId = :potId
+          AND ut.status = :status
+        GROUP BY ut.user.id
+        ORDER BY COUNT(ut.todoId) DESC
+    """)
+    Page<Long> findTopUserIdsByPotAndStatus(@Param("potId") Long potId,
+                                            @Param("status") TodoStatus status,
+                                            Pageable pageable);
+
+    // 상위 2명 편의 메서드
+    default List<Long> findTop2UserIds(Long potId, TodoStatus status) {
+        return findTopUserIdsByPotAndStatus(potId, status, PageRequest.of(0, 2)).getContent();
+    }
+
 
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩터링

### 반영 브랜치
dev -> main
### 작업 내용
- 투두 뱃지 수여 및 에러 조건 수정
- 팟 이름 수정 API 개발

### 테스트 결과
<img width="322" height="173" alt="스크린샷 2025-08-15 오후 3 21 07" src="https://github.com/user-attachments/assets/10562a07-14fa-44db-871a-818b5640db4f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 팟 이름 변경 엔드포인트 추가: PATCH /pots/{pot_id}/rename (소유자만 변경 가능)
* **Refactor**
  * 배지 부여 기준 개선: 서로 다른 완료자 기준으로 상위 2명에게만 부여하며, 완료자 수가 2명 미만이면 부여되지 않음
  * 일부 날짜 필드가 문자열로 저장되도록 변경
* **Documentation**
  * 특정 배지 API의 가능한 오류 코드 목록 정리
* **Style**
  * 오류 메시지 문구 변경: "TODO를 완료한 사람이 2명 미만입니다. 최소 2명 이상이어야 합니다."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->