### PR TITLE
[Feat/#423] api 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,10 @@ dependencies {
 
 	//
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	//hibernate
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.hibernate.common:hibernate-commons-annotations:6.0.6.Final'
 }
 
 

--- a/src/main/java/stackpot/stackpot/feed/service/FeedCommandServiceImpl.java
+++ b/src/main/java/stackpot/stackpot/feed/service/FeedCommandServiceImpl.java
@@ -1,6 +1,5 @@
 package stackpot.stackpot.feed.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -13,6 +12,7 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import stackpot.stackpot.apiPayload.code.status.ErrorStatus;
 import stackpot.stackpot.apiPayload.exception.handler.FeedHandler;
 import stackpot.stackpot.apiPayload.exception.handler.UserHandler;

--- a/src/main/java/stackpot/stackpot/pot/converter/PotConverter.java
+++ b/src/main/java/stackpot/stackpot/pot/converter/PotConverter.java
@@ -131,10 +131,12 @@ public class PotConverter{
                 .build();
     }
 
-    public PotSummaryDto toDto(Pot pot) {
+    public PotSummaryDto toDto(Pot pot, Boolean isMember) {
         return PotSummaryDto.builder()
                 .summary(pot.getPotSummary())
                 .potLan(splitLanguages(pot.getPotLan()))
+                .potName(pot.getPotName())
+                .isMember(isMember)
                 .build();
     }
 

--- a/src/main/java/stackpot/stackpot/pot/converter/PotMemberConverter.java
+++ b/src/main/java/stackpot/stackpot/pot/converter/PotMemberConverter.java
@@ -48,22 +48,21 @@ public class PotMemberConverter{
     }
 
     public PotMemberInfoResponseDto toKaKaoCreatorDto(PotMember entity) {
-        String creatorRole = RoleNameMapper.mapRoleName(entity.getUser().getRole().name());
+        String creatorRole = RoleNameMapper.mapRoleName(entity.getRoleName().name());
         String nicknameWithRole = entity.getUser().getNickname() + " " + creatorRole;
 
         return PotMemberInfoResponseDto.builder()
                 .potMemberId(entity.getPotMemberId())
                 .nickname(nicknameWithRole)
                 .potRole(entity.getRoleName().name())
-                .owner(true)
+                .owner(entity.isOwner()) // true 고정 대신 실제 owner 여부 반영 추천
                 .build();
     }
 
     public PotMemberInfoResponseDto toKaKaoMemberDto(PotMember entity) {
-        String roleName = entity.getPotApplication() != null
-                ? entity.getPotApplication().getPotRole().name()
+        String roleName = entity.getRoleName() != null
+                ? entity.getRoleName().name()
                 : "멤버";
-
 
         String nicknameWithRole;
 

--- a/src/main/java/stackpot/stackpot/pot/dto/PotSummaryDto.java
+++ b/src/main/java/stackpot/stackpot/pot/dto/PotSummaryDto.java
@@ -11,5 +11,7 @@ import java.util.List;
 public class PotSummaryDto {
     private String summary;
     private List<String> potLan;
+    private String potName;
+    private Boolean isMember;
 }
 

--- a/src/main/java/stackpot/stackpot/pot/service/pot/MyPotService.java
+++ b/src/main/java/stackpot/stackpot/pot/service/pot/MyPotService.java
@@ -13,6 +13,7 @@ public interface MyPotService {
     // 사용자의 진행 중인 팟 조회
     List<OngoingPotResponseDto> getMyPots();
     AppealContentDto getAppealContent(Long potId);
+    AppealContentDto getUserAppealContent(Long potId, Long targetUserId);
     PotSummaryDto getPotSummary(Long potId);
     List<CompletedPotBadgeResponseDto> getCompletedPotsWithBadges();
     List<CompletedPotBadgeResponseDto> getUserCompletedPotsWithBadges(Long userId);

--- a/src/main/java/stackpot/stackpot/user/controller/UserController.java
+++ b/src/main/java/stackpot/stackpot/user/controller/UserController.java
@@ -315,7 +315,22 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    @GetMapping("/potSummary{pot_id}")
+    @GetMapping("/potAppealContent/{pot_id}/{user_id}")
+    @Operation(
+            summary = "다른 사람 마이페이지 '여기서 저는요' 모달 조회 API",
+            description = "'끓인 팟 상세보기 모달'에 쓰이는 Role, Badge, Appeal Content를 반환합니다."
+    )
+    @ApiErrorCodeExamples({
+            ErrorStatus.USER_NOT_FOUND,
+    })
+    public ResponseEntity<ApiResponse<AppealContentDto>> getAppealContent(
+            @PathVariable(name = "pot_id") Long potId,
+            @PathVariable(name = "user_id") Long userId) {
+        AppealContentDto response = myPotService.getUserAppealContent(potId, userId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @GetMapping("/potSummary/{pot_id}")
     @Operation(
             summary = "끓인 팟 AI 요약 모달 조회 API",
             description = "끓인 팟을 상세보기할 때 쓰이는 PotSummary, potLan을 반환합니다."

--- a/src/main/java/stackpot/stackpot/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/stackpot/stackpot/user/service/UserCommandServiceImpl.java
@@ -1,12 +1,12 @@
 package stackpot.stackpot.user.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import stackpot.stackpot.apiPayload.code.status.ErrorStatus;
 import stackpot.stackpot.apiPayload.exception.GeneralException;
 import stackpot.stackpot.apiPayload.exception.handler.PotHandler;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩터링

### 반영 브랜치
dev -> main

### 작업 내용
* [FEAT/#423]
- 다른 사람 마이페이지 '여기서 저는요' 모달 조회

* [FEAT/#423]
- 끓인팟 요약 조회: 팟 이름이랑 팟 멤버인지 여부 (boolean) 추가

* [FEAT/#423]
- 권한 위임 API 오류 수정

* [FEAT/#423]
- 여기서 저는요 작성 및 수정 API 버그 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 특정 사용자의 호소(어필) 콘텐츠를 조회할 수 있는 엔드포인트 추가
  - Pot 요약 응답에 Pot 이름과 현재 사용자 멤버 여부가 포함

- 버그 수정
  - 멤버/생성자 역할명 및 소유자 여부 표시가 실제 상태와 일치하도록 개선
  - 소유권 위임 시 검증 강화로 잘못된 위임 방지

- 문서
  - 신규 엔드포인트에 대한 API 문서와 오류 사례 예시 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->