### PR TITLE
[Bug/#432] Todo의 소유자도 Member Role 받아오도록 수정 

### DIFF
--- a/src/main/java/stackpot/stackpot/todo/converter/UserTodoConverter.java
+++ b/src/main/java/stackpot/stackpot/todo/converter/UserTodoConverter.java
@@ -1,34 +1,36 @@
 package stackpot.stackpot.todo.converter;
 
+import org.springframework.stereotype.Component;
 import stackpot.stackpot.common.util.RoleNameMapper;
 import stackpot.stackpot.pot.entity.Pot;
 import stackpot.stackpot.todo.dto.MyPotTodoResponseDTO;
-
-import java.util.List;
-
-import org.springframework.stereotype.Component;
+import stackpot.stackpot.todo.entity.enums.TodoStatus;
 import stackpot.stackpot.todo.entity.mapping.UserTodo;
 import stackpot.stackpot.user.entity.User;
+import stackpot.stackpot.user.entity.enums.Role;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 @Component
-public class UserTodoConverter{
+public class UserTodoConverter {
 
+    // ✅ 멤버 역할(Role)을 직접 받도록 변경
     public MyPotTodoResponseDTO toDto(
             User member,
+            Role memberRole,          // ← PotMember.roleName
             Pot pot,
             List<UserTodo> todos,
             User current) {
 
-        String role = String.valueOf(member.getRole());
-        String nicknameWithRole = member.getNickname() + " " + RoleNameMapper.mapRoleName(role);
+        String roleName = memberRole != null ? memberRole.name() : Role.UNKNOWN.name();
+        String nicknameWithRole = member.getNickname() + " " + RoleNameMapper.mapRoleName(roleName);
 
         Integer notStartedCount = null;
         if (member.equals(current)) {
             notStartedCount = (int) todos.stream()
-                    .filter(t -> t.getStatus()==stackpot.stackpot.todo.entity.enums.TodoStatus.NOT_STARTED)
+                    .filter(t -> t.getStatus() == TodoStatus.NOT_STARTED)
                     .count();
         }
 
@@ -42,21 +44,30 @@ public class UserTodoConverter{
 
         return MyPotTodoResponseDTO.builder()
                 .userNickname(nicknameWithRole)
-                .userRole(member.getRole().name())
+                .userRole(roleName)        // ← User.role이 아니라 PotMember.roleName 기반
                 .userId(member.getId())
                 .todoCount(notStartedCount)
-                .todos(details.isEmpty()? null : details)
+                .todos(details.isEmpty() ? null : details)
                 .build();
     }
 
+    // 필요 시: 리스트 변환에서 roleMap을 함께 받는 버전
+    public List<MyPotTodoResponseDTO> toListDtoWithRoles(
+            Pot pot,
+            List<UserTodo> todos,
+            Map<User, Role> roleMap,
+            User current) {
 
-    public List<MyPotTodoResponseDTO> toListDto(Pot pot, List<UserTodo> todos) {
         Map<User, List<UserTodo>> grouped = todos.stream()
                 .collect(Collectors.groupingBy(UserTodo::getUser));
 
         return grouped.entrySet().stream()
-                .map(e -> toDto(e.getKey(), pot, e.getValue(), e.getKey()))
+                .map(e -> toDto(
+                        e.getKey(),
+                        roleMap.getOrDefault(e.getKey(), Role.UNKNOWN),
+                        pot,
+                        e.getValue(),
+                        current))
                 .collect(Collectors.toList());
     }
-
 }

--- a/src/main/java/stackpot/stackpot/todo/service/UserTodoServiceImpl.java
+++ b/src/main/java/stackpot/stackpot/todo/service/UserTodoServiceImpl.java
@@ -23,6 +23,7 @@ import stackpot.stackpot.todo.entity.mapping.UserTodo;
 import stackpot.stackpot.todo.repository.UserTodoRepository;
 import stackpot.stackpot.pot.repository.PotMemberRepository;
 import stackpot.stackpot.user.entity.User;
+import stackpot.stackpot.user.entity.enums.Role;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -43,69 +44,81 @@ public class UserTodoServiceImpl implements UserTodoService {
     @Transactional
     @Override
     public Page<MyPotTodoResponseDTO> getTodo(Long potId, PageRequest pageRequest) {
-        User user = authService.getCurrentUser();
+        User current = authService.getCurrentUser();
 
         Pot pot = potRepository.findById(potId)
                 .orElseThrow(() -> new PotHandler(ErrorStatus.POT_NOT_FOUND));
 
-        boolean isOwner = pot.getUser().equals(user);
-        boolean isMember = potMemberRepository.existsByPotAndUser(pot, user);
+        boolean isOwner = pot.getUser().equals(current);
+        boolean isMember = potMemberRepository.existsByPotAndUser(pot, current);
+        if (!isOwner && !isMember) throw new PotHandler(ErrorStatus.POT_FORBIDDEN);
 
-        if (!isOwner && !isMember) {
-            throw new PotHandler(ErrorStatus.POT_FORBIDDEN);
-        }
+        // PotMember 기준으로 전체 멤버 확보
+        List<PotMember> allMembers = potMemberRepository.findByPotId(pot.getPotId());
 
-        List<User> allPotMembers = potMemberRepository.findByPotId(pot.getPotId())
-                .stream()
+        // 현재 사용자 우선 정렬
+        allMembers.sort((m1, m2) -> {
+            boolean a = m1.getUser().equals(current);
+            boolean b = m2.getUser().equals(current);
+            return a == b ? 0 : (a ? -1 : 1);
+        });
+
+        int total = allMembers.size();
+        int start = (int) pageRequest.getOffset();
+        int end = Math.min(start + pageRequest.getPageSize(), total);
+        if (start >= total) return new PageImpl<>(List.of(), pageRequest, total);
+
+        // 페이징된 PotMember
+        List<PotMember> pageMembers = allMembers.subList(start, end);
+
+        // 쿼리용 사용자 리스트
+        List<User> pageUsers = pageMembers.stream()
                 .map(PotMember::getUser)
                 .collect(Collectors.toList());
 
-        allPotMembers.sort((u1, u2) -> u1.equals(user) ? -1 : (u2.equals(user) ? 1 : 0));
+        // 사용자별 역할(Role) 매핑 (멤버 역할)
+        Map<User, Role> roleMap = pageMembers.stream()
+                .collect(Collectors.toMap(PotMember::getUser,
+                        pm -> pm.getRoleName() != null ? pm.getRoleName() : Role.UNKNOWN));
 
-        int totalUsers = allPotMembers.size();
-        int startIndex = (int) pageRequest.getOffset();
-        int endIndex = Math.min(startIndex + pageRequest.getPageSize(), totalUsers);
+        // Todo 조회
+        List<UserTodo> todos = myPotRepository.findByPotAndUsers(pot, pageUsers);
 
-        if (startIndex >= totalUsers) {
-            return new PageImpl<>(List.of(), pageRequest, totalUsers);
-        }
-
-        List<User> pagedUsers = allPotMembers.subList(startIndex, endIndex);
-
-        List<UserTodo> todos = myPotRepository.findByPotAndUsers(pot, pagedUsers);
-
+        // 5AM 컷 필터
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime todayAt5AM = LocalDateTime.of(now.toLocalDate(), LocalTime.of(5, 0));
         LocalDateTime yesterdayAt5AM = todayAt5AM.minusDays(1);
 
-        List<UserTodo> filteredTodos = todos.stream()
-                .filter(todo -> todo.getCreatedAt().isAfter(yesterdayAt5AM))
+        List<UserTodo> filtered = todos.stream()
+                .filter(t -> t.getCreatedAt().isAfter(yesterdayAt5AM))
                 .collect(Collectors.toList());
 
-        Map<User, List<UserTodo>> groupedByUser = filteredTodos.stream()
+        Map<User, List<UserTodo>> grouped = filtered.stream()
                 .collect(Collectors.groupingBy(UserTodo::getUser));
 
-        List<MyPotTodoResponseDTO> responseList = pagedUsers.stream()
-                .map(member -> userTodoConverter.toDto(
-                        member,
+        // Converter에 멤버 역할(Role) 전달
+        List<MyPotTodoResponseDTO> response = pageMembers.stream()
+                .map(pm -> userTodoConverter.toDto(
+                        pm.getUser(),
+                        roleMap.getOrDefault(pm.getUser(), Role.UNKNOWN),
                         pot,
-                        groupedByUser.getOrDefault(member, List.of()),
-                        user))
+                        grouped.getOrDefault(pm.getUser(), List.of()),
+                        current))
                 .collect(Collectors.toList());
 
-        return new PageImpl<>(responseList, pageRequest, totalUsers);
+        return new PageImpl<>(response, pageRequest, total);
     }
 
 
     @Transactional
     @Override
     public List<MyPotTodoResponseDTO> updateTodos(Long potId, List<MyPotTodoUpdateRequestDTO> reqs) {
-        User user = authService.getCurrentUser();
+        User current = authService.getCurrentUser();
 
         Pot pot = potRepository.findById(potId)
                 .orElseThrow(() -> new PotHandler(ErrorStatus.POT_NOT_FOUND));
 
-        List<UserTodo> existing = myPotRepository.findByPot_PotIdAndUser(potId, user);
+        List<UserTodo> existing = myPotRepository.findByPot_PotIdAndUser(potId, current);
         Map<Long, UserTodo> existMap = existing.stream()
                 .collect(Collectors.toMap(UserTodo::getTodoId, t -> t));
 
@@ -122,7 +135,7 @@ public class UserTodoServiceImpl implements UserTodoService {
                 toSave.add(e);
             } else {
                 toSave.add(UserTodo.builder()
-                        .user(user).pot(pot)
+                        .user(current).pot(pot)
                         .content(r.getContent())
                         .status(r.getStatus() != null ? r.getStatus() : TodoStatus.NOT_STARTED)
                         .build());
@@ -135,27 +148,54 @@ public class UserTodoServiceImpl implements UserTodoService {
         myPotRepository.saveAll(toSave);
         myPotRepository.deleteAll(toDelete);
 
-        return userTodoConverter.toListDto(pot, toSave);
+        // ✅ current 사용자의 멤버 역할(Role) 구해 전달
+        Role currentRole = potMemberRepository.findByPotId(potId).stream()
+                .filter(pm -> pm.getUser().equals(current))
+                .map(PotMember::getRoleName)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(Role.UNKNOWN);
+
+        Map<User, List<UserTodo>> grouped = toSave.stream()
+                .collect(Collectors.groupingBy(UserTodo::getUser));
+
+        return grouped.entrySet().stream()
+                .map(e -> userTodoConverter.toDto(
+                        e.getKey(),
+                        currentRole,    // ← 멤버 역할 전달
+                        pot,
+                        e.getValue(),
+                        current))
+                .collect(Collectors.toList());
     }
 
     @Transactional
     @Override
     public List<MyPotTodoResponseDTO> completeTodo(Long potId, Long todoId) {
-        User user = authService.getCurrentUser();
+        User current = authService.getCurrentUser();
 
-        potRepository.findById(potId)
+        Pot pot = potRepository.findById(potId)
                 .orElseThrow(() -> new PotHandler(ErrorStatus.POT_NOT_FOUND));
 
         UserTodo todo = myPotRepository.findByTodoIdAndPot_PotId(todoId, potId)
                 .orElseThrow(() -> new PotHandler(ErrorStatus.USER_TODO_NOT_FOUND));
-        if (!todo.getUser().equals(user)) throw new PotHandler(ErrorStatus.USER_TODO_UNAUTHORIZED);
+
+        if (!todo.getUser().equals(current)) {
+            throw new PotHandler(ErrorStatus.USER_TODO_UNAUTHORIZED);
+        }
 
         todo.setStatus(todo.getStatus() == TodoStatus.COMPLETED
                 ? TodoStatus.NOT_STARTED : TodoStatus.COMPLETED);
         myPotRepository.save(todo);
 
         List<UserTodo> all = myPotRepository.findByPot_PotId(potId);
-        return userTodoConverter.toListDto(todo.getPot(), all);
+
+        // ✅ User → Role 매핑 (멤버 역할)
+        Map<User, Role> roleMap = potMemberRepository.findByPotId(potId).stream()
+                .collect(Collectors.toMap(PotMember::getUser,
+                        pm -> pm.getRoleName() != null ? pm.getRoleName() : Role.UNKNOWN));
+
+        return userTodoConverter.toListDtoWithRoles(pot, all, roleMap, current);
     }
 
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩터링

### 반영 브랜치
dev -> main

### 작업 내용
- 투두의 생성자도 member Role 받아오도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 역할 기반 투두 표시: 각 멤버의 역할을 함께 노출하며, 미지정 시 ‘알 수 없음’으로 표시됩니다.
  * 멤버별 페이징 조회: 포트 멤버 목록과 해당 투두를 페이지 단위로 조회할 수 있습니다.
  * 최신 투두 기준 개선: 어제 새벽 5시 이후 생성된 투두를 중심으로 표시합니다.

* 버그 수정
  * 권한 검증 강화: 비소유자/비멤버의 투두 접근을 제한하고, 본인 투두에 대해서만 완료 토글이 가능하도록 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->