### PR TITLE
[Bug/#483] 저장 api 수정

### DIFF
--- a/src/main/java/stackpot/stackpot/feed/service/FeedQueryServiceImpl.java
+++ b/src/main/java/stackpot/stackpot/feed/service/FeedQueryServiceImpl.java
@@ -340,6 +340,9 @@ public class FeedQueryServiceImpl implements FeedQueryService {
 
         // 미리 좋아요한 피드 ID 조회
         List<Long> likedFeedIds = feedLikeRepository.findFeedIdsByUserId(user.getId());
+        
+        // 미리 저장한 피드 ID 조회
+        List<Long> savedFeedIds = feedSaveRepository.findFeedIdsByUserId(user.getId());
 
         // 저장 수 조회
         List<Object[]> rawResults = feedSaveRepository.countSavesByFeedIds(feedIds);
@@ -353,7 +356,7 @@ public class FeedQueryServiceImpl implements FeedQueryService {
         List<FeedResponseDto.FeedDto> content = feeds.stream()
                 .map(feed -> {
                     Long feedId = feed.getFeedId();
-                    boolean isSaved = true;
+                    boolean isSaved = savedFeedIds.contains(feedId);
                     boolean isLiked = likedFeedIds.contains(feedId);
                     boolean isOwner = feed.getUser().getId().equals(user.getId());
                     int saveCount = saveCountMap.getOrDefault(feedId, 0);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩터링

### 반영 브랜치
dev -> main

### 작업 내용
* [FIX/#483] 피드 저장 상태 표시 에러 수정
* [FIX/#483] OpenAI 사용하는 방식으로 롤백

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 좋아요 표시한 피드 조회 시 개별 피드의 저장 여부가 사용자의 실제 저장 상태에 따라 정확하게 표시되도록 수정되었습니다. 이전에는 모든 피드가 저장된 것으로 잘못 표시되던 문제를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->